### PR TITLE
feat(events): Persist activities + CRUD + draft publish/unpublish (implements #9)

### DIFF
--- a/src/data/activities.json
+++ b/src/data/activities.json
@@ -1,0 +1,109 @@
+{
+  "Chess Club": {
+    "description": "Learn strategies and compete in chess tournaments",
+    "schedule": "Fridays, 3:30 PM - 5:00 PM",
+    "max_participants": 12,
+    "participants": [
+      "michael@mergington.edu",
+      "daniel@mergington.edu"
+    ],
+    "draft": false,
+    "poster": null
+  },
+  "Programming Class": {
+    "description": "Learn programming fundamentals and build software projects",
+    "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
+    "max_participants": 20,
+    "participants": [
+      "emma@mergington.edu",
+      "sophia@mergington.edu"
+    ],
+    "draft": false,
+    "poster": null
+  },
+  "Gym Class": {
+    "description": "Physical education and sports activities",
+    "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
+    "max_participants": 30,
+    "participants": [
+      "john@mergington.edu",
+      "olivia@mergington.edu"
+    ],
+    "draft": false,
+    "poster": null
+  },
+  "Soccer Team": {
+    "description": "Join the school soccer team and compete in matches",
+    "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
+    "max_participants": 22,
+    "participants": [
+      "liam@mergington.edu",
+      "noah@mergington.edu"
+    ],
+    "draft": false,
+    "poster": null
+  },
+  "Basketball Team": {
+    "description": "Practice and play basketball with the school team",
+    "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
+    "max_participants": 15,
+    "participants": [
+      "ava@mergington.edu",
+      "mia@mergington.edu"
+    ],
+    "draft": false,
+    "poster": null
+  },
+  "Art Club": {
+    "description": "Explore your creativity through painting and drawing",
+    "schedule": "Thursdays, 3:30 PM - 5:00 PM",
+    "max_participants": 15,
+    "participants": [
+      "amelia@mergington.edu",
+      "harper@mergington.edu"
+    ],
+    "draft": true,
+    "poster": null
+  },
+  "Drama Club": {
+    "description": "Act, direct, and produce plays and performances",
+    "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
+    "max_participants": 20,
+    "participants": [
+      "ella@mergington.edu",
+      "scarlett@mergington.edu"
+    ],
+    "draft": true,
+    "poster": null
+  },
+  "Math Club": {
+    "description": "Solve challenging problems and participate in math competitions",
+    "schedule": "Tuesdays, 3:30 PM - 4:30 PM",
+    "max_participants": 10,
+    "participants": [
+      "james@mergington.edu",
+      "benjamin@mergington.edu"
+    ],
+    "draft": false,
+    "poster": null
+  },
+  "Debate Team": {
+    "description": "Develop public speaking and argumentation skills",
+    "schedule": "Fridays, 4:00 PM - 5:30 PM",
+    "max_participants": 12,
+    "participants": [
+      "charlotte@mergington.edu",
+      "henry@mergington.edu"
+    ],
+    "draft": false,
+    "poster": null
+  },
+  "GitHub Skills": {
+    "description": "New MCP-based coding activity",
+    "schedule": "Saturdays",
+    "max_participants": 25,
+    "participants": [],
+    "poster": null,
+    "draft": false
+  }
+}


### PR DESCRIPTION
This PR implements the core of issue #9: Event CRUD with Draft/Publish and persistence beyond in-memory storage.

Summary:
- Replace in-memory activities with JSON persistence at `src/data/activities.json`.
- Add loader/saver helpers in `src/app.py` to persist across restarts.
- Public listing `GET /activities` now returns only published items (`draft=false`).
- Admin listing `GET /activities/all` returns all items, including drafts.
- New endpoints:
  - `POST /activities` (create, defaults to `draft=true`)
  - `PUT /activities/{activity_name}` (update fields)
  - `DELETE /activities/{activity_name}` (delete)
  - `POST /activities/{activity_name}/publish` / `unpublish`
- Preserve existing signup/unregister routes; saving changes back to disk.

Acceptance alignment:
- Events persist across server restarts via JSON storage.
- Only published events appear in public listings.
- CRUD and publish/unpublish are available for hosts/admins to use.

Notes:
- Chosen JSON persistence to avoid new dependencies and keep the exercise simple; can be upgraded to SQLite later.
- Frontend continues to read `/activities`; published-only filtering is automatic.

Closes #9.